### PR TITLE
fix race conditions in ratelimit

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Test
-        run: go test ./...
+        run: go test -race ./...
 
       - name: Build Example
         run: go build example/main.go

--- a/adaptive_ratelimit_test.go
+++ b/adaptive_ratelimit_test.go
@@ -1,26 +1,17 @@
 package ratelimit_test
 
-import (
-	"context"
-	"testing"
-	"time"
+// func TestAdaptiveRateLimit(t *testing.T) {
+// 	limiter := ratelimit.NewUnlimited(context.Background())
+// 	start := time.Now()
 
-	"github.com/projectdiscovery/ratelimit"
-	"github.com/stretchr/testify/require"
-)
-
-func TestAdaptiveRateLimit(t *testing.T) {
-	limiter := ratelimit.NewUnlimited(context.Background())
-	start := time.Now()
-
-	for i := 0; i < 132; i++ {
-		limiter.Take()
-		// got 429 / hit ratelimit after 100
-		if i == 100 {
-			// Retry-After and new limiter (calibrate using different statergies)
-			// new expected ratelimit 30req every 5 sec
-			limiter.SleepandReset(time.Duration(5)*time.Second, 30, time.Duration(5)*time.Second)
-		}
-	}
-	require.Equal(t, time.Since(start).Round(time.Second), time.Duration(10)*time.Second)
-}
+// 	for i := 0; i < 132; i++ {
+// 		limiter.Take()
+// 		// got 429 / hit ratelimit after 100
+// 		if i == 100 {
+// 			// Retry-After and new limiter (calibrate using different statergies)
+// 			// new expected ratelimit 30req every 5 sec
+// 			limiter.SleepandReset(time.Duration(5)*time.Second, 30, time.Duration(5)*time.Second)
+// 		}
+// 	}
+// 	require.Equal(t, time.Since(start).Round(time.Second), time.Duration(10)*time.Second)
+// }

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require github.com/stretchr/testify v1.8.1
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/projectdiscovery/utils v0.0.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/projectdiscovery/ratelimit
 
 go 1.18
 
-require (
-	github.com/stretchr/testify v1.8.1
-	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15
-)
+require github.com/stretchr/testify v1.8.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15 h1:5oN1Pz/eDhCpbMbLstvIPa0b/BEQo6g6nwV3pLjfM6w=
-golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/projectdiscovery/utils v0.0.6 h1:6SDn/5E5NxrAfcYrZ7omXPmiU9n8p0rKXZ4BAOQyzbw=
+github.com/projectdiscovery/utils v0.0.6/go.mod h1:PCwA5YuCYWPgHaGiZmr53/SA9iGQmAnw7DSHuhr8VPQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/keyratelimit.go
+++ b/keyratelimit.go
@@ -81,8 +81,8 @@ func (m *MultiLimiter) AddAndTake(opts *Options) {
 		limiter.Take()
 		return
 	}
-	m.Add(opts)
-	m.Take(opts.Key)
+	_ = m.Add(opts)
+	_ = m.Take(opts.Key)
 }
 
 // Stop internal limiters with defined keys or all if no key is provided

--- a/keyratelimit_test.go
+++ b/keyratelimit_test.go
@@ -19,6 +19,7 @@ func TestMultiLimiter(t *testing.T) {
 	})
 	require.Nil(t, err)
 	wg := &sync.WaitGroup{}
+	expectedTime := (time.Duration(6) * time.Second).Round(time.Millisecond)
 
 	wg.Add(1)
 	go func() {
@@ -28,8 +29,7 @@ func TestMultiLimiter(t *testing.T) {
 			errx := limiter.Take("default")
 			require.Nil(t, errx, "failed to take")
 		}
-		timeTaken := time.Since(defaultStart)
-		expectedTime := time.Duration(6) * time.Second
+		timeTaken := time.Since(defaultStart).Round(time.Millisecond)
 		require.GreaterOrEqualf(t, timeTaken.Nanoseconds(), expectedTime.Nanoseconds(), "more token sent than requested in given timeframe")
 	}()
 
@@ -49,8 +49,7 @@ func TestMultiLimiter(t *testing.T) {
 			errx := limiter.Take("one")
 			require.Nil(t, errx)
 		}
-		timeTaken := time.Since(oneStart)
-		expectedTime := time.Duration(6) * time.Second
+		timeTaken := time.Since(oneStart).Round(time.Millisecond)
 		require.GreaterOrEqualf(t, timeTaken.Nanoseconds(), expectedTime.Nanoseconds(), "more token sent than requested in given timeframe")
 	}()
 	wg.Wait()

--- a/keyratelimit_test.go
+++ b/keyratelimit_test.go
@@ -24,11 +24,11 @@ func TestMultiLimiter(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		defaultStart := time.Now()
-		for i := 0; i < 201; i++ {
+		for i := 0; i < 202; i++ {
 			errx := limiter.Take("default")
 			require.Nil(t, errx, "failed to take")
 		}
-		require.Greater(t, time.Since(defaultStart), time.Duration(6)*time.Second)
+		require.Greater(t, time.Since(defaultStart).Nanoseconds(), (time.Duration(6) * time.Second).Nanoseconds())
 	}()
 
 	err = limiter.Add(&ratelimit.Options{
@@ -43,11 +43,11 @@ func TestMultiLimiter(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		oneStart := time.Now()
-		for i := 0; i < 201; i++ {
+		for i := 0; i < 202; i++ {
 			errx := limiter.Take("one")
 			require.Nil(t, errx)
 		}
-		require.Greater(t, time.Since(oneStart), time.Duration(6)*time.Second)
+		require.Greater(t, time.Since(oneStart).Nanoseconds(), (time.Duration(6) * time.Second).Nanoseconds())
 	}()
 	wg.Wait()
 }

--- a/keyratelimit_test.go
+++ b/keyratelimit_test.go
@@ -24,11 +24,13 @@ func TestMultiLimiter(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		defaultStart := time.Now()
-		for i := 0; i < 202; i++ {
+		for i := 0; i < 201; i++ {
 			errx := limiter.Take("default")
 			require.Nil(t, errx, "failed to take")
 		}
-		require.Greater(t, time.Since(defaultStart).Nanoseconds(), (time.Duration(6) * time.Second).Nanoseconds())
+		timeTaken := time.Since(defaultStart)
+		expectedTime := time.Duration(6) * time.Second
+		require.GreaterOrEqualf(t, timeTaken.Nanoseconds(), expectedTime.Nanoseconds(), "more token sent than requested in given timeframe")
 	}()
 
 	err = limiter.Add(&ratelimit.Options{
@@ -43,11 +45,13 @@ func TestMultiLimiter(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		oneStart := time.Now()
-		for i := 0; i < 202; i++ {
+		for i := 0; i < 201; i++ {
 			errx := limiter.Take("one")
 			require.Nil(t, errx)
 		}
-		require.Greater(t, time.Since(oneStart).Nanoseconds(), (time.Duration(6) * time.Second).Nanoseconds())
+		timeTaken := time.Since(oneStart)
+		expectedTime := time.Duration(6) * time.Second
+		require.GreaterOrEqualf(t, timeTaken.Nanoseconds(), expectedTime.Nanoseconds(), "more token sent than requested in given timeframe")
 	}()
 	wg.Wait()
 }

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -21,13 +21,13 @@ func TestRateLimit(t *testing.T) {
 			limiter.Take()
 			count++
 		}
-		took := time.Since(start)
+		took := time.Since(start).Nanoseconds()
 		require.Equal(t, count, 10)
-		require.True(t, took < expected)
+		require.Less(t, took, expected.Nanoseconds())
 		// take another one above max
 		limiter.Take()
-		took = time.Since(start)
-		require.True(t, took >= expected)
+		took = time.Since(start).Nanoseconds()
+		require.GreaterOrEqual(t, took, expected.Nanoseconds())
 	})
 
 	t.Run("Unlimited Rate Limit", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestRateLimit(t *testing.T) {
 		}
 		took := time.Since(start)
 		require.Equal(t, count, 1000)
-		require.True(t, took < time.Duration(1*time.Second))
+		require.Lessf(t, took.Nanoseconds(), time.Duration(1*time.Second).Nanoseconds(), "burst rate of unlimited ratelimit is too low")
 	})
 
 	t.Run("Concurrent Rate Limit Use", func(t *testing.T) {
@@ -70,8 +70,8 @@ func TestRateLimit(t *testing.T) {
 		limiter.Stop()
 		took := time.Since(start)
 		require.Equal(t, expected, int(count))
-		require.True(t, took >= time.Duration(10*time.Second))
-		require.True(t, took <= time.Duration(12*time.Second))
+		require.GreaterOrEqualf(t, took, time.Duration(10*time.Second).Nanoseconds(), "ratelimit timeframe mismatch should be > 10s")
+		require.LessOrEqualf(t, took, time.Duration(12*time.Second).Nanoseconds(), "ratelimit timeframe mismatch should be < 10s")
 	})
 
 	t.Run("Time comparsion", func(t *testing.T) {

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -67,6 +67,7 @@ func TestRateLimit(t *testing.T) {
 		}
 
 		wg.Wait()
+		limiter.Stop()
 		took := time.Since(start)
 		require.Equal(t, expected, int(count))
 		require.True(t, took >= time.Duration(10*time.Second))

--- a/ratelimit_test.go
+++ b/ratelimit_test.go
@@ -73,4 +73,16 @@ func TestRateLimit(t *testing.T) {
 		require.True(t, took >= time.Duration(10*time.Second))
 		require.True(t, took <= time.Duration(12*time.Second))
 	})
+
+	t.Run("Time comparsion", func(t *testing.T) {
+		limiter := New(context.TODO(), 100, time.Duration(3)*time.Second)
+		// if ratelimit works correctly it should take at least 6 sec to take/consume 201 tokens
+		startTime := time.Now()
+		for i := 0; i < 201; i++ {
+			limiter.Take()
+		}
+		timetaken := time.Since(startTime)
+		expected := time.Duration(6) * time.Second
+		require.GreaterOrEqualf(t, timetaken.Nanoseconds(), expected.Nanoseconds(), "more tokens sent than expected with ratelimit")
+	})
 }


### PR DESCRIPTION
## Proposed Changes

- fix race conditions (concurrent map writes) in `MultiLimiter` 
- minor improvement with closing token channel
- adds `-race` flag in github action build workflow
- Commented/removed `SleepandReset` method due to since it is not stable and needs improvements and has race conditions (requires entire change of logic)
- adds `AddandTake(opts *Options)` method #23 
- resolves https://github.com/projectdiscovery/nuclei/pull/3257

closes
- #23 
- #26 